### PR TITLE
feat: add IssueCard and details page

### DIFF
--- a/lib/models/issue.dart
+++ b/lib/models/issue.dart
@@ -2,12 +2,15 @@ class Issue {
   final String id;
   String title;
   String description;
-  final DateTime createdAt;
+  final DateTime createdAt = DateTime.now();
 
   Issue({
     required this.id,
     required this.title,
     required this.description,
-    required this.createdAt,
+   
   });
+
+  String get createdAtString => createdAt.toLocal().toString().split('.').first;
+
 }

--- a/lib/models/issue.dart
+++ b/lib/models/issue.dart
@@ -1,0 +1,13 @@
+class Issue {
+  final String id;
+  String title;
+  String description;
+  final DateTime createdAt;
+
+  Issue({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.createdAt,
+  });
+}

--- a/lib/widgets/issue_card.dart
+++ b/lib/widgets/issue_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:kanban_issues_app/models/issue.dart';
 
+import '../views/issue_details.dart';
+
 class IssueCard extends StatelessWidget {
   final Issue issue;
   const IssueCard({super.key, required this.issue});
@@ -40,7 +42,14 @@ class IssueCard extends StatelessWidget {
                     ),
                   ),
                   TextButton(
-                    onPressed: () {},
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => IssueDetails(issue: issue),
+                        ),
+                      );
+                    },
                     child: const Text(
                       'View Details',
                       style: TextStyle(color: Colors.white),

--- a/lib/widgets/issue_card.dart
+++ b/lib/widgets/issue_card.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:kanban_issues_app/models/issue.dart';
+
+class IssueCard extends StatelessWidget {
+  final Issue issue;
+  const IssueCard({super.key, required this.issue});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.all(16.0),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 3,
+      child: SizedBox(
+        width: 300,
+        height: 200,
+
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // HEADER
+            Container(
+              decoration: const BoxDecoration(
+                color: Color.fromARGB(255, 143, 42, 42),
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(12),
+                  topRight: Radius.circular(12),
+                ),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'ID ${issue.id}',
+                    style: const TextStyle(
+                      fontSize: 18.0,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () {},
+                    child: const Text(
+                      'View Details',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // BODY
+            Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    issue.title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 6),
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: Text(
+                      issue.description,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    issue.createdAtString,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `Issue` model and a corresponding `IssueCard` widget to display issue information in the UI. 

**Models**

* Added a new `Issue` class in `lib/models/issue.dart` with fields for `id`, `title`, `description`, and `createdAt`, as well as a formatted getter for the creation date.

**UI Components**

* Implemented the `IssueCard` widget in `lib/widgets/issue_card.dart` to visually display issue details, including the issue ID, title, description, and creation date, and added navigation to a detailed view.